### PR TITLE
OPR-309 L'enregistrement ne fonctionne pas sous IE

### DIFF
--- a/bower-locker-common.js
+++ b/bower-locker-common.js
@@ -27,7 +27,7 @@ function mapDependencyData(bowerInfo) {
         name: bowerInfo.name,
         originalSrc: bowerInfo._originalSource,
         release: bowerInfo._release,
-        src: bowerInfo._source,
+        src: bowerInfo._target === "*" ? bowerInfo._originalSource : bowerInfo._source,
         tag: tag,
         type: type
     };

--- a/bower-locker-lock.js
+++ b/bower-locker-lock.js
@@ -39,6 +39,7 @@ function lock(isVerbose) {
 
     // Create new bower config from existing
     bowerConfig.bowerLocker = {lastUpdated: (new Date()).toISOString()};
+    bowerConfig.resolutions = {};
     bowerConfig.dependencies = {};
     // Remove devDependency section to prevent version collision
     delete bowerConfig.devDependencies;

--- a/bower-locker-lock.js
+++ b/bower-locker-lock.js
@@ -47,10 +47,10 @@ function lock(isVerbose) {
         // NOTE: Use dirName as the dependency name as it is more accurate than .bower.json properties
         var name = dep.dirName;
         var version = dep.type === 'branch' ? dep.branch : dep.release;
-        bowerConfig.dependencies[name] = dep.src + (version ? '#' + version: ""); // _source
+        bowerConfig.dependencies[name] = dep.src + (version ? '#' + version: ''); // _source
         if(!bowerConfig.resolutions[name]) {
-            bowerConfig.resolutions[name] = version ? version : "*";
-        } else if (bowerConfig.resolutions[name] !== "*") {
+            bowerConfig.resolutions[name] = version ? version : '*';
+        } else if (bowerConfig.resolutions[name] !== '*') {
             bowerConfig.resolutions[name] = version
         }
         if (isVerbose) {

--- a/bower-locker-lock.js
+++ b/bower-locker-lock.js
@@ -39,7 +39,6 @@ function lock(isVerbose) {
 
     // Create new bower config from existing
     bowerConfig.bowerLocker = {lastUpdated: (new Date()).toISOString()};
-    bowerConfig.resolutions = {};
     bowerConfig.dependencies = {};
     // Remove devDependency section to prevent version collision
     delete bowerConfig.devDependencies;
@@ -48,8 +47,12 @@ function lock(isVerbose) {
         // NOTE: Use dirName as the dependency name as it is more accurate than .bower.json properties
         var name = dep.dirName;
         var version = dep.type === 'branch' ? dep.branch : dep.release;
-        bowerConfig.dependencies[name] = dep.src + '#' + version; // _source
-        bowerConfig.resolutions[name] = version;
+        bowerConfig.dependencies[name] = dep.src + (version ? '#' + version: ""); // _source
+        if(!bowerConfig.resolutions[name]) {
+            bowerConfig.resolutions[name] = version ? version : "*";
+        } else if (bowerConfig.resolutions[name] !== "*") {
+            bowerConfig.resolutions[name] = version
+        }
         if (isVerbose) {
             console.log('  %s (%s): %s', name, dep.release, dep.commit);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@udes/bower-locker",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "A command-line tool for locking, unlocking, and validating bower files",
   "keywords": [
     "bower",


### PR DESCRIPTION
Modification afin de pouvoir utiliser des composants locaux et des composants sans numéro de version.